### PR TITLE
Fix CSS syntax error in achievements style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,7 +20,7 @@ body {
     text-align: left;
     background: url('parchment_texture.jpg') center/cover no-repeat;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
-    font-size: 20px
+    font-size: 20px;
     color: #FFFFFF;
     font-family: 'Papyrus', fantasy;
     max-width: 500px; /* Limits width */


### PR DESCRIPTION
## Summary
- add missing semicolon after `font-size` in `styles.css`

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68419736748083288cf2811668dfd2cf