### PR TITLE
Fix malformed URLs in JSON

### DIFF
--- a/detailed_achievements.json
+++ b/detailed_achievements.json
@@ -147,7 +147,7 @@
     {
         "title": "Flex in the City",
         "description": "You killed a city boss with the participation of five or less crawlers. That is some serious badassery right there. Color me impressed. Now go do it again with a Province Boss.\n\nReward: You already got a boss box. Go open that instead.",
-        "url": "hhttps://dungeon-crawler-carl.fandom.com/wiki/Flex_in_the_City"
+        "url": "https://dungeon-crawler-carl.fandom.com/wiki/Flex_in_the_City"
     },
     {
         "title": "Fuck This Floor Achievement",
@@ -457,7 +457,7 @@
     {
         "title": "We Want Meat! We Want Meat!",
         "description": "Thunder Down Under, Magic Mike, Chippendales. While the female burlesque and peepshow has a long, interesting history going back centuries, the all-male revue as an attraction is a relatively recent phenomenon in your culture.  It wasn't until the disco era did some entrepreneurs start to realize that packs of women were a valid demographic in the art of taking money from horny people.\n\nTake a physically gifted, steroid-enhanced male, give him some dancing lessons, teeth whitening strips, a shower, a banana, a Guns N Roses CD, and an entire bottle of baby oil, and then you basically plop him into the equivalent of the inside of a female restroom at a nightclub, and you've got yourself a money making empire. Also, you may not have noticed this yet, but there's a hierarchy to these things in the Desperado Club. The deeper the floor, the higher the quality of the performers. At least that's how it's supposed to be. you might want to judge for yourself.\n\nYou've entered a male strip club establishment.\n\nReward: You've received 10 gold pieces to use as tips. I heard some of them let you stuff the gold directly into their G-strings. Aw hell, I've thrown in a bottle of hand sanitizer too.",
-        "url": "hhttps://dungeon-crawler-carl.fandom.com/wiki/We_Want_Meat!_We_Want_Meat!"
+        "url": "https://dungeon-crawler-carl.fandom.com/wiki/We_Want_Meat!_We_Want_Meat!"
     },
     {
         "title": "Welcome to the Neighborhood! Achievement",


### PR DESCRIPTION
## Summary
- correct `hhttps://` URL prefixes in `detailed_achievements.json`

## Testing
- `python3 -m json.tool detailed_achievements.json`

------
https://chatgpt.com/codex/tasks/task_e_6841995183e88328923502ab791a119c